### PR TITLE
Use a independent tokio runtime to wait for task completion

### DIFF
--- a/bin/loom_anvil/src/main.rs
+++ b/bin/loom_anvil/src/main.rs
@@ -16,8 +16,8 @@ use log::{debug, error, info};
 use debug_provider::AnvilDebugProviderFactory;
 use defi_actors::{
     fetch_and_add_pool_by_address, fetch_state_and_add_pool, AnvilBroadcastActor, ArbSwapPathMergerActor, BlockHistoryActor,
-    DiffPathMergerActor, EvmEstimatorActor, GasStationActor, InitializeSignersActor, MarketStatePreloadedActor, NodeBlockActor,
-    NonceAndBalanceMonitorActor, PriceActor, SamePathMergerActor, StateChangeArbActor, SwapEncoderActor, TxSignersActor,
+    DiffPathMergerActor, EvmEstimatorActor, GasStationActor, InitializeSignersOneShotActor, MarketStatePreloadedOneShotActor,
+    NodeBlockActor, NonceAndBalanceMonitorActor, PriceActor, SamePathMergerActor, StateChangeArbActor, SwapEncoderActor, TxSignersActor,
 };
 use defi_entities::{
     AccountNonceAndBalanceState, BlockHistory, GasStation, LatestBlock, Market, MarketState, PoolClass, Swap, Token, TxSigners,
@@ -169,7 +169,7 @@ async fn main() -> Result<()> {
 
     info!("Starting initialize signers actor");
 
-    let mut initialize_signers_actor = InitializeSignersActor::new(Some(priv_key.to_bytes().to_vec()));
+    let mut initialize_signers_actor = InitializeSignersOneShotActor::new(Some(priv_key.to_bytes().to_vec()));
     match initialize_signers_actor.access(tx_signers.clone()).access(accounts_state.clone()).start_and_wait() {
         Err(e) => {
             error!("{}", e);
@@ -201,7 +201,7 @@ async fn main() -> Result<()> {
 
     info!("Starting market state preload actor");
     let mut market_state_preload_actor =
-        MarketStatePreloadedActor::new(client.clone()).with_encoder(&encoder).with_signers(tx_signers.clone());
+        MarketStatePreloadedOneShotActor::new(client.clone()).with_encoder(&encoder).with_signers(tx_signers.clone());
     match market_state_preload_actor.access(market_state.clone()).start_and_wait() {
         Err(e) => {
             error!("{}", e)

--- a/crates/defi-actors/src/lib.rs
+++ b/crates/defi-actors/src/lib.rs
@@ -9,7 +9,7 @@ pub use market::{
     fetch_and_add_pool_by_address, fetch_state_and_add_pool, HistoryPoolLoaderActor, NewPoolLoaderActor, ProtocolPoolLoaderActor,
     RequiredPoolLoaderActor,
 };
-pub use market_state::{preload_market_state, MarketStatePreloadedActor};
+pub use market_state::{preload_market_state, MarketStatePreloadedOneShotActor};
 pub use mempool::MempoolActor;
 pub use mergers::{ArbSwapPathMergerActor, DiffPathMergerActor, SamePathMergerActor};
 pub use node::{NodeBlockActor, NodeMempoolActor};
@@ -17,7 +17,7 @@ pub use node_exex_grpc::NodeExExGrpcActor;
 pub use node_player::NodeBlockPlayerActor;
 pub use pathencoder::SwapEncoderActor;
 pub use price::PriceActor;
-pub use signers::{InitializeSignersActor, TxSignersActor};
+pub use signers::{InitializeSignersOneShotActor, TxSignersActor};
 pub use tx_broadcaster::{AnvilBroadcastActor, FlashbotsBroadcastActor};
 
 mod market;

--- a/crates/defi-actors/src/market_state/mod.rs
+++ b/crates/defi-actors/src/market_state/mod.rs
@@ -1,3 +1,3 @@
-pub use preloader_actor::{preload_market_state, MarketStatePreloadedActor};
+pub use preloader_actor::{preload_market_state, MarketStatePreloadedOneShotActor};
 
 mod preloader_actor;

--- a/crates/defi-actors/src/signers/mod.rs
+++ b/crates/defi-actors/src/signers/mod.rs
@@ -1,4 +1,4 @@
-pub use initialize_actor::InitializeSignersActor;
+pub use initialize_actor::InitializeSignersOneShotActor;
 pub use signers_actor::TxSignersActor;
 
 mod initialize_actor;

--- a/crates/defi-actors/src/signers/signers_actor.rs
+++ b/crates/defi-actors/src/signers/signers_actor.rs
@@ -12,7 +12,13 @@ use loom_actors::{Actor, ActorResult, Broadcaster, Consumer, Producer, WorkerRes
 use loom_actors_macros::{Accessor, Consumer, Producer};
 
 async fn sign_task(sign_request: TxComposeData, compose_channel_tx: Broadcaster<MessageTxCompose>) -> Result<()> {
-    let signer = sign_request.signer.clone().unwrap();
+    let signer = match sign_request.signer.clone() {
+        Some(signer) => signer,
+        None => {
+            error!("No signer found in sign_request");
+            return Err(eyre!("NO_SIGNER_FOUND"));
+        }
+    };
 
     let rlp_bundle: Vec<RlpState> = sign_request
         .tx_bundle
@@ -46,7 +52,6 @@ async fn sign_task(sign_request: TxComposeData, compose_channel_tx: Broadcaster<
         error!("Bundle is not ready. Cannot sign");
         return Err(eyre!("CANNOT_SIGN_BUNDLE"));
     }
-    //let rlp_bundle= rlp_bundle.into_iter().map(|item| item.unwrap()).collect();
 
     let broadcast_request = TxComposeData { rlp_bundle: Some(rlp_bundle), ..sign_request };
 
@@ -73,7 +78,6 @@ async fn request_listener_worker(
                     Ok(compose_request) =>{
 
                         if let TxCompose::Sign( sign_request)= compose_request.inner {
-                            //let rlp_bundle : Vec<Option<Bytes>> = Vec::new();
                             tokio::task::spawn(
                                 sign_task(
                                     sign_request,

--- a/crates/defi-entities/src/swappath.rs
+++ b/crates/defi-entities/src/swappath.rs
@@ -105,6 +105,8 @@ impl SwapPaths {
         if self.paths.insert(rc_path.clone()) {
             for pool in rc_path.pools.iter() {
                 let e = self.pool_paths.entry(pool.get_address()).or_insert(Arc::new(HashSet::new()));
+                // TODO: Fix this clippy warning
+                #[allow(clippy::mutable_key_type)]
                 let mut v = e.clone().deref().clone();
                 v.insert(rc_path.clone());
                 *e = Arc::new(v);
@@ -121,6 +123,8 @@ impl SwapPaths {
         if self.paths.insert(rc_path.clone()) {
             for pool in rc_path.pools.iter() {
                 let e = self.pool_paths.entry(pool.get_address()).or_insert(Arc::new(HashSet::new()));
+                // TODO: Fix this clippy warning
+                #[allow(clippy::mutable_key_type)]
                 let mut v = e.clone().deref().clone();
                 v.insert(rc_path.clone());
                 *e = Arc::new(v);

--- a/crates/topology/src/topology.rs
+++ b/crates/topology/src/topology.rs
@@ -13,7 +13,7 @@ use tokio::task::JoinHandle;
 
 use defi_actors::{
     BlockHistoryActor, EvmEstimatorActor, FlashbotsBroadcastActor, GasStationActor, GethEstimatorActor, HistoryPoolLoaderActor,
-    InitializeSignersActor, MarketStatePreloadedActor, MempoolActor, NewPoolLoaderActor, NodeBlockActor, NodeExExGrpcActor,
+    InitializeSignersOneShotActor, MarketStatePreloadedOneShotActor, MempoolActor, NewPoolLoaderActor, NodeBlockActor, NodeExExGrpcActor,
     NodeMempoolActor, NonceAndBalanceMonitorActor, PoolHealthMonitorActor, PriceActor, ProtocolPoolLoaderActor, TxSignersActor,
 };
 use defi_blockchain::Blockchain;
@@ -186,7 +186,7 @@ impl Topology {
                     info!("Starting initialize env signers actor {name}");
                     let blockchain = topology.get_blockchain(params.blockchain.as_ref()).unwrap();
 
-                    let mut initialize_signers_actor = InitializeSignersActor::new_from_encrypted_env();
+                    let mut initialize_signers_actor = InitializeSignersOneShotActor::new_from_encrypted_env();
                     match initialize_signers_actor.access(signers.clone()).access(blockchain.nonce_and_balance()).start_and_wait() {
                         Ok(_) => {
                             info!("Signers have been initialized")
@@ -221,13 +221,13 @@ impl Topology {
                 let signers = topology.get_signers(params.signers.as_ref()).unwrap();
 
                 let mut market_state_preload_actor =
-                    MarketStatePreloadedActor::new(client).with_signers(signers.clone()).with_encoder(&topology.get_encoder(None)?);
+                    MarketStatePreloadedOneShotActor::new(client).with_signers(signers.clone()).with_encoder(&topology.get_encoder(None)?);
                 match market_state_preload_actor.access(blockchain.market_state()).start_and_wait() {
                     Ok(_) => {
                         info!("Market state preload actor executed successfully")
                     }
                     Err(e) => {
-                        panic!("MarketStatePreloadedActor : {}", e)
+                        panic!("MarketStatePreloadedOneShotActor : {}", e)
                     }
                 }
             }


### PR DESCRIPTION
- Refactor to use a independent tokio runtime for one-shot actors. Using thread sleep caused some issues for me during startup where the actor never finished.
-  Rename actors that only run for a fixed time to OneShotActors
- There are two clippy error. I did not liked to touch the code here and marked them as TODO.
- The `#[async_trait]` is obsolete for the actors. I did not included all changes here to not blow this PR up.