### PR TITLE
Allow to configure individual the node block actor active channels

### DIFF
--- a/bin/loom_anvil/src/main.rs
+++ b/bin/loom_anvil/src/main.rs
@@ -17,7 +17,8 @@ use debug_provider::AnvilDebugProviderFactory;
 use defi_actors::{
     fetch_and_add_pool_by_address, fetch_state_and_add_pool, AnvilBroadcastActor, ArbSwapPathMergerActor, BlockHistoryActor,
     DiffPathMergerActor, EvmEstimatorActor, GasStationActor, InitializeSignersOneShotActor, MarketStatePreloadedOneShotActor,
-    NodeBlockActor, NonceAndBalanceMonitorActor, PriceActor, SamePathMergerActor, StateChangeArbActor, SwapEncoderActor, TxSignersActor,
+    NodeBlockActor, NodeBlockActorConfig, NonceAndBalanceMonitorActor, PriceActor, SamePathMergerActor, StateChangeArbActor,
+    SwapEncoderActor, TxSignersActor,
 };
 use defi_entities::{
     AccountNonceAndBalanceState, BlockHistory, GasStation, LatestBlock, Market, MarketState, PoolClass, Swap, Token, TxSigners,
@@ -214,7 +215,7 @@ async fn main() -> Result<()> {
     //load_pools(client.clone(), market_instance.clone(), market_state.clone()).await?;
 
     info!("Starting node actor");
-    let mut node_block_actor = NodeBlockActor::new(client.clone());
+    let mut node_block_actor = NodeBlockActor::new(client.clone(), NodeBlockActorConfig::all_enabled());
     match node_block_actor
         .produce(new_block_headers_channel.clone())
         .produce(new_block_with_tx_channel.clone())

--- a/crates/defi-actors/src/blockchain_actors/actor.rs
+++ b/crates/defi-actors/src/blockchain_actors/actor.rs
@@ -5,7 +5,7 @@ use crate::backrun::BlockStateChangeProcessorActor;
 use crate::{
     ArbSwapPathMergerActor, BlockHistoryActor, DiffPathMergerActor, EvmEstimatorActor, FlashbotsBroadcastActor, GasStationActor,
     GethEstimatorActor, HistoryPoolLoaderActor, InitializeSignersOneShotActor, MarketStatePreloadedOneShotActor, MempoolActor,
-    NewPoolLoaderActor, NodeBlockActor, NodeExExGrpcActor, NodeMempoolActor, NonceAndBalanceMonitorActor,
+    NewPoolLoaderActor, NodeBlockActor, NodeBlockActorConfig, NodeExExGrpcActor, NodeMempoolActor, NonceAndBalanceMonitorActor,
     PendingTxStateChangeProcessorActor, PoolHealthMonitorActor, PriceActor, ProtocolPoolLoaderActor, RequiredPoolLoaderActor,
     SamePathMergerActor, StateChangeArbSearcherActor, StateHealthMonitorActor, SwapEncoderActor, TxSignersActor,
 };
@@ -200,13 +200,15 @@ where
 
     /// Starts receiving blocks events through RPC
     pub fn with_block_events(&mut self) -> Result<&mut Self> {
-        self.actor_manager.start(NodeBlockActor::new(self.provider.clone()).on_bc(&self.bc))?;
+        self.actor_manager.start(NodeBlockActor::new(self.provider.clone(), NodeBlockActorConfig::all_enabled()).on_bc(&self.bc))?;
         Ok(self)
     }
 
     /// Starts receiving blocks events through direct Reth DB access
     pub fn reth_node_with_blocks(&mut self, db_path: String) -> Result<&mut Self> {
-        self.actor_manager.start(NodeBlockActor::new(self.provider.clone()).on_bc(&self.bc).with_reth_db(Some(db_path)))?;
+        self.actor_manager.start(
+            NodeBlockActor::new(self.provider.clone(), NodeBlockActorConfig::all_enabled()).on_bc(&self.bc).with_reth_db(Some(db_path)),
+        )?;
         Ok(self)
     }
 

--- a/crates/defi-actors/src/lib.rs
+++ b/crates/defi-actors/src/lib.rs
@@ -12,7 +12,7 @@ pub use market::{
 pub use market_state::{preload_market_state, MarketStatePreloadedOneShotActor};
 pub use mempool::MempoolActor;
 pub use mergers::{ArbSwapPathMergerActor, DiffPathMergerActor, SamePathMergerActor};
-pub use node::{NodeBlockActor, NodeMempoolActor};
+pub use node::{NodeBlockActor, NodeBlockActorConfig, NodeMempoolActor};
 pub use node_exex_grpc::NodeExExGrpcActor;
 pub use node_player::NodeBlockPlayerActor;
 pub use pathencoder::SwapEncoderActor;

--- a/crates/defi-actors/src/node/mod.rs
+++ b/crates/defi-actors/src/node/mod.rs
@@ -1,4 +1,4 @@
-pub use node_block_actor::NodeBlockActor;
+pub use node_block_actor::{NodeBlockActor, NodeBlockActorConfig};
 pub use node_mempool_actor::NodeMempoolActor;
 
 mod node_block_actor;

--- a/crates/defi-actors/src/node/node_block_actor.rs
+++ b/crates/defi-actors/src/node/node_block_actor.rs
@@ -51,9 +51,54 @@ where
     Ok(tasks)
 }
 
+#[derive(Debug, Clone)]
+pub struct NodeBlockActorConfig {
+    pub block_header: bool,
+    pub block_with_tx: bool,
+    pub block_logs: bool,
+    pub block_state_update: bool,
+}
+
+impl NodeBlockActorConfig {
+    pub fn new() -> Self {
+        Self { block_header: false, block_with_tx: false, block_logs: false, block_state_update: false }
+    }
+
+    pub fn all_enabled() -> Self {
+        Self { block_header: true, block_with_tx: true, block_logs: true, block_state_update: true }
+    }
+
+    pub fn with_block_header(mut self) -> Self {
+        self.block_header = true;
+        self
+    }
+
+    pub fn with_block_with_tx(mut self) -> Self {
+        self.block_with_tx = true;
+        self
+    }
+
+    pub fn with_block_logs(mut self) -> Self {
+        self.block_logs = true;
+        self
+    }
+
+    pub fn with_block_state_update(mut self) -> Self {
+        self.block_state_update = true;
+        self
+    }
+}
+
+impl Default for NodeBlockActorConfig {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[derive(Producer)]
 pub struct NodeBlockActor<P, T> {
     client: P,
+    config: NodeBlockActorConfig,
     reth_db_path: Option<String>,
     #[producer]
     block_header_channel: Option<Broadcaster<Header>>,
@@ -75,9 +120,10 @@ where
         "NodeBlockActor"
     }
 
-    pub fn new(client: P) -> NodeBlockActor<P, T> {
+    pub fn new(client: P, config: NodeBlockActorConfig) -> NodeBlockActor<P, T> {
         NodeBlockActor {
             client,
+            config,
             reth_db_path: None,
             block_header_channel: None,
             block_with_tx_channel: None,
@@ -93,10 +139,10 @@ where
 
     pub fn on_bc(self, bc: &Blockchain) -> Self {
         Self {
-            block_header_channel: Some(bc.new_block_headers_channel()),
-            block_with_tx_channel: Some(bc.new_block_with_tx_channel()),
-            block_logs_channel: Some(bc.new_block_logs_channel()),
-            block_state_update_channel: Some(bc.new_block_state_update_channel()),
+            block_header_channel: if self.config.block_header { Some(bc.new_block_headers_channel()) } else { None },
+            block_with_tx_channel: if self.config.block_with_tx { Some(bc.new_block_with_tx_channel()) } else { None },
+            block_logs_channel: if self.config.block_logs { Some(bc.new_block_logs_channel()) } else { None },
+            block_state_update_channel: if self.config.block_state_update { Some(bc.new_block_state_update_channel()) } else { None },
             ..self
         }
     }
@@ -141,11 +187,11 @@ mod test {
     use log::{debug, error, info};
     use tokio::select;
 
+    use crate::node::node_block_actor::NodeBlockActorConfig;
+    use crate::NodeBlockActor;
     use defi_events::{BlockLogs, BlockStateUpdate};
     use eyre::Result;
     use loom_actors::{Actor, Broadcaster, Producer};
-
-    use crate::NodeBlockActor;
 
     #[tokio::test]
     #[ignore]
@@ -166,7 +212,7 @@ mod test {
 
         let db_path = std::env::var("TEST_NODE_DB")?;
 
-        let mut node_block_actor = NodeBlockActor::new(client.clone()).with_reth_db(Some(db_path));
+        let mut node_block_actor = NodeBlockActor::new(client.clone(), NodeBlockActorConfig::all_enabled()).with_reth_db(Some(db_path));
         match node_block_actor
             .produce(new_block_headers_channel.clone())
             .produce(new_block_with_tx_channel.clone())

--- a/crates/topology/src/topology.rs
+++ b/crates/topology/src/topology.rs
@@ -13,8 +13,9 @@ use tokio::task::JoinHandle;
 
 use defi_actors::{
     BlockHistoryActor, EvmEstimatorActor, FlashbotsBroadcastActor, GasStationActor, GethEstimatorActor, HistoryPoolLoaderActor,
-    InitializeSignersOneShotActor, MarketStatePreloadedOneShotActor, MempoolActor, NewPoolLoaderActor, NodeBlockActor, NodeExExGrpcActor,
-    NodeMempoolActor, NonceAndBalanceMonitorActor, PoolHealthMonitorActor, PriceActor, ProtocolPoolLoaderActor, TxSignersActor,
+    InitializeSignersOneShotActor, MarketStatePreloadedOneShotActor, MempoolActor, NewPoolLoaderActor, NodeBlockActor,
+    NodeBlockActorConfig, NodeExExGrpcActor, NodeMempoolActor, NonceAndBalanceMonitorActor, PoolHealthMonitorActor, PriceActor,
+    ProtocolPoolLoaderActor, TxSignersActor,
 };
 use defi_blockchain::Blockchain;
 use defi_entities::TxSigners;
@@ -268,7 +269,8 @@ impl Topology {
                 let client_config = topology.get_client_config(params.client.as_ref()).unwrap();
 
                 info!("Starting node actor {name}");
-                let mut node_block_actor = NodeBlockActor::new(client).with_reth_db(client_config.db_path);
+                let mut node_block_actor =
+                    NodeBlockActor::new(client, NodeBlockActorConfig::all_enabled()).with_reth_db(client_config.db_path);
                 match node_block_actor
                     .produce(blockchain.new_block_headers_channel())
                     .produce(blockchain.new_block_with_tx_channel())


### PR DESCRIPTION
Sometime you like to save resources or have different state management. For that reason the user of loom should decide what node events he likes to fetch. Logs and state can be very resource intensive.

Example if only headers and blocks with txs should be fetched:
_(By default new() all options are off)_
```rust
NodeBlockActorConfig::new().with_block_header().with_block_with_tx()
```


Enable all:
```rust
NodeBlockActorConfig::all_enabled()
```