### PR TITLE
Add exceptions to deny list

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11748,9 +11748,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.3"
+version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d157f1b96d14500ffdc1f10ba712e780825526c03d9a49b4d0324b0d9113ada"
+checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
 dependencies = [
  "form_urlencoded",
  "idna",

--- a/deny.toml
+++ b/deny.toml
@@ -28,8 +28,10 @@ name = "ring"
 
 [advisories]
 ignore = [
-  # proc-macro-error 1.0.4 is unmaintained see: https://rustsec.org/advisories/RUSTSEC-2024-0370
-  "RUSTSEC-2024-0370",
+  # fast-float used in revm-inspectors - https://rustsec.org/advisories/RUSTSEC-2024-0379
+  "RUSTSEC-2024-0379",
+  # rustls used in alloy-transport-ws - https://rustsec.org/advisories/RUSTSEC-2024-0399
+  "RUSTSEC-2024-0399",
 ]
 yanked = "warn"
 


### PR DESCRIPTION
Make deny-check happy again. Found advisors do not affect loom.